### PR TITLE
rm AsUser option

### DIFF
--- a/songslack_src.go
+++ b/songslack_src.go
@@ -193,7 +193,6 @@ func postToSlack(username string, attendanceType string, songkickEvent Event) er
 		Short: true})
 
 	err := slackClient.ChatPostMessage(slackChannel.Id, message, &slack.ChatPostMessageOpt{
-		AsUser:   true,
 		Username: username,
 		Attachments: []*slack.Attachment{
 			{


### PR DESCRIPTION
turns out it means "as the user the token belongs to", not just "as the user" ;)
